### PR TITLE
Allow Nette 4 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,12 +18,12 @@
   "require": {
     "php": ">=7.2",
     "nette/di": "^3.1.0",
-    "nette/utils": "^3.2.8"
+    "nette/utils": "^3.2.8 || ^4.0"
   },
   "require-dev": {
     "ninjify/qa": "^0.13",
     "ninjify/nunjuck": "^0.4",
-    "nette/robot-loader": "^3.4.2",
+    "nette/robot-loader": "^3.4.2 || ^4.0",
     "nette/bootstrap": "^3.1.4",
     "phpstan/phpstan": "^1.9.11",
     "phpstan/phpstan-deprecation-rules": "^1.1.1",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -17,3 +17,4 @@ parameters:
 		- src
 
 	ignoreErrors:
+		- '/Call to deprecated method startsWith\(\) of class Nette\\Utils\\Strings:\nuse str_starts_with\(\)/' # TODO: remove after dropping PHP 7 support

--- a/tests/Cases/Extension/ResourceExtension.phpt
+++ b/tests/Cases/Extension/ResourceExtension.phpt
@@ -265,7 +265,7 @@ test(static function (): void {
 					paths: [%appDir%/Fixtures/Scalar]
 		', 'neon'));
 		}, 12);
-	}, ServiceCreationException::class, "Service 'autoload._Tests_Fixtures_Scalar_.2' (type of Tests\Fixtures\Scalar\ScalarService): Parameter \$text in ScalarService::__construct() has no class type or default value, so its value must be specified.");
+	}, ServiceCreationException::class, '~Service \'autoload\._Tests_Fixtures_Scalar_\.\d+\' \(type of Tests\\\\Fixtures\\\\Scalar\\\\ScalarService\): Parameter \$text in ScalarService::__construct\(\) has no class type or default value, so its value must be specified\.~');
 });
 
 // Register services manually (exception)


### PR DESCRIPTION
This is pretty straightforward PR. There is one controversial thing: ignoring deprecation notice from phpstan/phpstan-deprecation-rules, but I don't see an easy way around it without dropping PHP 7 support.